### PR TITLE
Fix/underscored function and directories

### DIFF
--- a/pywit/interface.py
+++ b/pywit/interface.py
@@ -1,1 +1,2 @@
 from xwakes.wit.interface import *
+from xwakes.wit.interface import _create_iw2d_input_from_dict

--- a/xwakes/init_pywit_directory.py
+++ b/xwakes/init_pywit_directory.py
@@ -6,7 +6,7 @@ def initialize_pywit_directory() -> None:
     home_path = pathlib.Path.home()
     paths = [home_path.joinpath('pywit').joinpath(ext) for ext in ('config', 'IW2D/bin', 'IW2D/projects')]
     for path in paths:
-        os.makedirs(path, exist_ok=True)
+        os.makedirs(path)
     with open(pathlib.Path(paths[0]).joinpath('iw2d_settings.yaml'), 'w') as file:
         file.write(f'binary_directory: {paths[1]}\n'
                    f'project_directory: {paths[2]}')


### PR DESCRIPTION
2 changes:

- we add explicitly an underscored function to the pywit interface. This will disappear when we will finally transition `pywit` -> `xwakes->wit`
- the installation requires creating a `pywit` repository in our home. For safety we break if a `pywit` repository already exists