### PR TITLE
Feature: enable tracking on GPUs

### DIFF
--- a/examples/001d_instability_wake_table_gpu.py
+++ b/examples/001d_instability_wake_table_gpu.py
@@ -1,0 +1,146 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import hilbert
+from scipy.stats import linregress
+
+import xtrack as xt
+import xpart as xp
+import xwakes as xw
+import xfields as xf
+import xobjects as xo
+
+context = xo.ContextCupy(device=3)
+#context = xo.ContextCpu()
+
+# Simulation settings
+n_turns = 1000
+
+wake_table_filename = xf.general._pkg_root.joinpath(
+    '../test_data/HLLHC_wake.dat')
+wake_file_columns = ['time', 'longitudinal', 'dipole_x', 'dipole_y',
+                     'quadrupole_x', 'quadrupole_y', 'dipole_xy',
+                     'quadrupole_xy', 'dipole_yx', 'quadrupole_yx',
+                     'constant_x', 'constant_y']
+mytable = xw.read_headtail_file(
+    wake_file=wake_table_filename,
+    wake_file_columns=wake_file_columns
+)
+wf = xw.WakeFromTable(
+    table=mytable,
+    columns=['dipole_x', 'dipole_y', 'quadrupole_x', 'quadrupole_y'],
+)
+wf.configure_for_tracking(
+    zeta_range=(-0.375, 0.375),
+    num_slices=100,
+    num_turns=1,
+    _context=context
+)
+
+one_turn_map = xt.LineSegmentMap(
+    length=27e3, betx=70., bety=80.,
+    qx=62.31, qy=60.32,
+    longitudinal_mode='linear_fixed_qs',
+    dqx=-10., dqy=-10.,  # <-- to see fast mode-0 instability
+    qs=2e-3, bets=731.27,
+    _context=context
+)
+
+# Generate line
+line = xt.Line(elements=[one_turn_map, wf],
+               element_names=['one_turn_map', 'wf'])
+
+
+line.particle_ref = xt.Particles(p0c=7e12, _context=context)
+line.build_tracker(_context=context)
+
+# Generate particles
+particles = xp.generate_matched_gaussian_bunch(line=line,
+                    num_particles=40_000_000, total_intensity_particles=2.3e11,
+                    nemitt_x=2e-6, nemitt_y=2e-6, sigma_z=0.075,
+                    _context=context)
+
+# Apply a distortion to the bunch to trigger an instability
+amplitude = 1e-3
+particles.x += amplitude
+particles.y += amplitude
+
+flag_plot = True
+
+mean_x_xt = np.zeros(n_turns)
+mean_y_xt = np.zeros(n_turns)
+
+plt.ion()
+
+fig1 = plt.figure(figsize=(6.4*1.7, 4.8))
+ax_x = fig1.add_subplot(121)
+line1_x, = ax_x.plot(mean_x_xt, 'r-', label='average x-position')
+line2_x, = ax_x.plot(mean_x_xt, 'm-', label='exponential fit')
+ax_x.set_ylim(-3.5, -1)
+ax_x.set_xlim(0, n_turns)
+ax_y = fig1.add_subplot(122, sharex=ax_x)
+line1_y, = ax_y.plot(mean_y_xt, 'b-', label='average y-position')
+line2_y, = ax_y.plot(mean_y_xt, 'c-', label='exponential fit')
+ax_y.set_ylim(-3.5, -1)
+ax_y.set_xlim(0, n_turns)
+
+plt.xlabel('turn')
+plt.ylabel('log10(average x-position)')
+plt.legend()
+
+turns = np.linspace(0, n_turns - 1, n_turns)
+
+import time
+
+line.track(particles, num_turns=1)
+
+start = time.time()
+
+for i_turn in range(n_turns):
+    line.track(particles, num_turns=1)
+
+    if i_turn % 50 == 0:
+        print(f'Turn: {i_turn}')
+
+    '''
+    mean_x_xt[i_turn] = np.mean(particles.x)
+    mean_y_xt[i_turn] = np.mean(particles.y)
+
+    if i_turn % 50 == 0 and i_turn > 1:
+        i_fit_end = np.argmax(mean_x_xt)  # i_turn
+        i_fit_start = int(i_fit_end * 0.9)
+
+        # compute x instability growth rate
+        ampls_x_xt = np.abs(hilbert(mean_x_xt))
+        fit_x_xt = linregress(turns[i_fit_start: i_fit_end],
+                              np.log(ampls_x_xt[i_fit_start: i_fit_end]))
+
+        # compute y instability growth rate
+
+        ampls_y_xt = np.abs(hilbert(mean_y_xt))
+        fit_y_xt = linregress(turns[i_fit_start: i_fit_end],
+                              np.log(ampls_y_xt[i_fit_start: i_fit_end]))
+
+        line1_x.set_xdata(turns[:i_turn])
+        line1_x.set_ydata(np.log10(np.abs(mean_x_xt[:i_turn])))
+        line2_x.set_xdata(turns[:i_turn])
+        line2_x.set_ydata(np.log10(np.exp(fit_x_xt.intercept +
+                                          fit_x_xt.slope*turns[:i_turn])))
+
+        line1_y.set_xdata(turns[:i_turn])
+        line1_y.set_ydata(np.log10(np.abs(mean_y_xt[:i_turn])))
+        line2_y.set_xdata(turns[:i_turn])
+        line2_y.set_ydata(np.log10(np.exp(fit_y_xt.intercept +
+                                          fit_y_xt.slope*turns[:i_turn])))
+        print(f'xtrack h growth rate: {fit_x_xt.slope}')
+        print(f'xtrack v growth rate: {fit_y_xt.slope}')
+
+        fig1.canvas.draw()
+        fig1.canvas.flush_events()
+
+        out_folder = '.'
+        np.save(f'{out_folder}/mean_x.npy', mean_x_xt)
+        np.save(f'{out_folder}/mean_y.npy', mean_y_xt)
+    '''
+
+end = time.time()
+print(f'Time: {end - start}')

--- a/tests/test_xwakes_kick_vs_pyheadtail.py
+++ b/tests/test_xwakes_kick_vs_pyheadtail.py
@@ -7,15 +7,18 @@ from scipy.constants import c as clight
 import xwakes as xw
 import xtrack as xt
 import xobjects as xo
+from xobjects.test_helpers import for_all_test_contexts
 
 test_data_folder = pathlib.Path(__file__).parent.joinpath(
     '../test_data').absolute()
 
-def test_xwakes_kick_vs_pyheadtail_table_dipolar():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_table_dipolar(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
-    p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000))
+    p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000),
+                    _context=test_context)
     p.x[p.zeta > 0] += 1e-3
     p.y[p.zeta > 0] += 1e-3
     p_table = p.copy()
@@ -31,7 +34,8 @@ def test_xwakes_kick_vs_pyheadtail_table_dipolar():
                         'quadrupolar_xy', 'dipolar_yx', 'quadrupolar_yx',
                         'constant_x', 'constant_y'])
     wake_from_table = xw.WakeFromTable(table, columns=['dipolar_x', 'dipolar_y'])
-    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=100)
+    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=100,
+                                           _context=test_context)
 
     # Zotter convention
     assert table['dipolar_x'].values[1] > 0
@@ -72,11 +76,13 @@ def test_xwakes_kick_vs_pyheadtail_table_dipolar():
     xo.assert_allclose(p_table.px, p_ref.px, atol=1e-30, rtol=2e-3)
     xo.assert_allclose(p_table.py, p_ref.py, atol=1e-30, rtol=2e-3)
 
-def test_xwakes_kick_vs_pyheadtail_table_quadrupolar():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_table_quadrupolar(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
-    p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000))
+    p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000),
+                     _context=test_context)
     p.x[p.zeta > 0] += 1e-3
     p.y[p.zeta > 0] += 1e-3
     p_table = p.copy()
@@ -93,7 +99,8 @@ def test_xwakes_kick_vs_pyheadtail_table_quadrupolar():
                         'constant_x', 'constant_y'])
 
     wake_from_table = xw.WakeFromTable(table, columns=['quadrupolar_x', 'quadrupolar_y'])
-    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=100)
+    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=100,
+                                           _context=test_context)
 
     # This is specific of this table
     assert table['quadrupolar_x'].values[1] < 0
@@ -136,13 +143,16 @@ def test_xwakes_kick_vs_pyheadtail_table_quadrupolar():
     xo.assert_allclose(p_table.py, p_ref.py, atol=1e-30, rtol=2e-3)
 
 
-def test_xwakes_kick_vs_pyheadtail_table_longitudinal():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_table_longitudinal(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
     p = xt.Particles.merge([
-        xt.Particles(p0c=7e12, zeta=np.linspace(-1e-3, 1e-3, 100000)),
-        xt.Particles(p0c=7e12, zeta=1e-6+np.zeros(100000))
+        xt.Particles(p0c=7e12, zeta=np.linspace(-1e-3, 1e-3, 100000),
+                     _context=test_context),
+        xt.Particles(p0c=7e12, zeta=1e-6+np.zeros(100000),
+                     _context=test_context),
     ])
 
     p_table = p.copy()
@@ -158,7 +168,9 @@ def test_xwakes_kick_vs_pyheadtail_table_longitudinal():
                         'quadrupolar_xy', 'dipolar_yx', 'quadrupolar_yx',
                         'constant_x', 'constant_y'])
     wake_from_table = xw.WakeFromTable(table, columns=['time', 'longitudinal'])
-    wake_from_table.configure_for_tracking(zeta_range=(-2e-3, 2e-3), num_slices=1000)
+    wake_from_table.configure_for_tracking(zeta_range=(-2e-3, 2e-3),
+                                           num_slices=1000,
+                                           _context=test_context)
 
     assert len(wake_from_table.components) == 1
     assert wake_from_table.components[0].plane == 'z'
@@ -191,12 +203,13 @@ def test_xwakes_kick_vs_pyheadtail_table_longitudinal():
     assert np.max(p_ref.delta) > 1e-12
     xo.assert_allclose(p_table.delta, p_ref.delta, atol=1e-14, rtol=0)
 
-def test_xwakes_kick_vs_pyheadtail_resonator_dipolar():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_resonator_dipolar(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
     p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000),
-                    weight=1e14)
+                    weight=1e14, _context=test_context)
     p.x[p.zeta > 0] += 1e-3
     p.y[p.zeta > 0] += 1e-3
     p_table = p.copy()
@@ -207,7 +220,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_dipolar():
         r=1e8, q=1e7, f_r=1e9,
         kind=xw.Yokoya('circular'), # equivalent to: kind=['dipolar_x', 'dipolar_y'],
     )
-    wake.configure_for_tracking(zeta_range=(-1, 1), num_slices=50)
+    wake.configure_for_tracking(zeta_range=(-1, 1), num_slices=50,
+                                _context=test_context)
 
     assert len(wake.components) == 2
     assert wake.components[0].plane == 'x'
@@ -237,7 +251,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_dipolar():
     table = pd.DataFrame({'time': t_samples, 'dipolar_x': w_dipole_x_samples,
                             'dipolar_y': w_dipole_y_samples})
     wake_from_table = xw.WakeFromTable(table)
-    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=50)
+    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=50,
+                                           _context=test_context)
 
     assert len(wake_from_table.components) == 2
     assert wake_from_table.components[0].plane == 'x'
@@ -277,12 +292,13 @@ def test_xwakes_kick_vs_pyheadtail_resonator_dipolar():
     xo.assert_allclose(p_table.px, p_ref.px, rtol=0, atol=2e-3*np.max(np.abs(p_ref.px)))
     xo.assert_allclose(p_table.py, p_ref.py, rtol=0, atol=2e-3*np.max(np.abs(p_ref.py)))
 
-def test_xwakes_kick_vs_pyheadtail_resonator_quadrupolar():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_resonator_quadrupolar(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
     p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000),
-                    weight=1e14)
+                    weight=1e14, _context=test_context)
     p.x[p.zeta > 0] += 1e-3
     p.y[p.zeta > 0] += 1e-3
     p_table = p.copy()
@@ -293,7 +309,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_quadrupolar():
         r=1e8, q=1e7, f_r=1e9,
         kind=['quadrupolar_x', 'quadrupolar_y'],
     )
-    wake.configure_for_tracking(zeta_range=(-1, 1), num_slices=50)
+    wake.configure_for_tracking(zeta_range=(-1, 1), num_slices=50,
+                                _context=test_context)
 
     assert len(wake.components) == 2
     assert wake.components[0].plane == 'x'
@@ -322,7 +339,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_quadrupolar():
     table = pd.DataFrame({'time': t_samples, 'quadrupolar_x': w_quadrupole_x_samples,
                             'quadrupolar_y': w_quadrupole_y_samples})
     wake_from_table = xw.WakeFromTable(table)
-    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=50)
+    wake_from_table.configure_for_tracking(zeta_range=(-1, 1), num_slices=50,
+                                           _context=test_context)
 
     assert len(wake_from_table.components) == 2
     assert wake_from_table.components[0].plane == 'x'
@@ -365,12 +383,13 @@ def test_xwakes_kick_vs_pyheadtail_resonator_quadrupolar():
     xo.assert_allclose(p_table.px, p_ref.px, rtol=0, atol=2e-3*np.max(np.abs(p_ref.px)))
     xo.assert_allclose(p_table.py, p_ref.py, rtol=0, atol=2e-3*np.max(np.abs(p_ref.py)))
 
-def test_xwakes_kick_vs_pyheadtail_resonator_longitudinal():
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_xwakes_kick_vs_pyheadtail_resonator_longitudinal(test_context):
 
     from xpart.pyheadtail_interface.pyhtxtparticles import PyHtXtParticles
 
     p = xt.Particles(p0c=7e12, zeta=np.linspace(-1, 1, 100000),
-                    weight=1e14)
+                     weight=1e14, _context=test_context)
     p.x[p.zeta > 0] += 1e-3
     p.y[p.zeta > 0] += 1e-3
     p_table = p.copy()
@@ -381,7 +400,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_longitudinal():
         r=1e8, q=1e7, f_r=1e9,
         kind='longitudinal'
     )
-    wake.configure_for_tracking(zeta_range=(-1.01, 1.01), num_slices=50)
+    wake.configure_for_tracking(zeta_range=(-1.01, 1.01), num_slices=50,
+                                _context=test_context)
 
     assert len(wake.components) == 1
     assert wake.components[0].plane == 'z'
@@ -402,7 +422,8 @@ def test_xwakes_kick_vs_pyheadtail_resonator_longitudinal():
     w_longitudinal_x_samples[0] *= 2 # Undo sampling weight
     table = pd.DataFrame({'time': t_samples, 'longitudinal': w_longitudinal_x_samples})
     wake_from_table = xw.WakeFromTable(table)
-    wake_from_table.configure_for_tracking(zeta_range=(-1.01, 1.01), num_slices=50)
+    wake_from_table.configure_for_tracking(zeta_range=(-1.01, 1.01), num_slices=50,
+                                           _context=test_context)
 
     assert len(wake_from_table.components) == 1
     assert wake_from_table.components[0].plane == 'z'

--- a/tests/test_xwakes_wake_kicks.py
+++ b/tests/test_xwakes_wake_kicks.py
@@ -13,7 +13,7 @@ import pathlib
 test_data_folder = pathlib.Path(__file__).parent.joinpath(
     '../test_data').absolute()
 
-exclude_contexts = ['ContextPyopencl', 'ContextCupy']
+exclude_contexts = ['ContextPyopencl', 'ContextCpu']
 
 kind_to_parameters = {
     'longitudinal': {'plane': 'z', 'source_exponents': (0, 0), 'test_exponents': (0, 0)},
@@ -79,12 +79,13 @@ def test_wake_kick_single_bunch(test_context, kind, wake_type):
         zeta_range=zeta_range,
         num_slices=num_slices,
         bunch_spacing_zeta=circumference/h_bunch,
-        circumference=circumference
+        circumference=circumference,
+        _context=test_context
         )
 
     line = xt.Line(elements=[wf])
-    line.build_tracker()
-    line.particle_ref=xp.Particles(p0c=p0c)
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(p0c=p0c)
 
     particles = xp.Particles(p0c=p0c,
                         zeta=wf.slicer.zeta_centers.flatten(),
@@ -130,14 +131,18 @@ def test_wake_kick_single_bunch(test_context, kind, wake_type):
         assert comp.test_exponents == kind_to_parameters[kk]['test_exponents']
 
         expected = np.zeros_like(particles.zeta)
+        x_cpu = test_context.nparray_from_context_array(particles.x)
+        y_cpu = test_context.nparray_from_context_array(particles.y)
+        zeta_cpu = test_context.nparray_from_context_array(particles.zeta)
+        beta0_cpu = test_context.nparray_from_context_array(particles.beta0)
 
-        for i_test, z_test in enumerate(particles.zeta):
-            expected[i_test] += (particles.x[i_test]**comp.test_exponents[0] *
-                                particles.y[i_test]**comp.test_exponents[1] *
-                                np.dot(particles.x**comp.source_exponents[0] *
-                                        particles.y**comp.source_exponents[1],
-                                        comp.function_vs_zeta(z_test - particles.zeta,
-                                                            beta0=particles.beta0[0],
+        for i_test, z_test in enumerate(zeta_cpu):
+            expected[i_test] += (x_cpu[i_test]**comp.test_exponents[0] *
+                                 y_cpu[i_test]**comp.test_exponents[1] *
+                                 np.dot(x_cpu**comp.source_exponents[0] *
+                                        y_cpu**comp.source_exponents[1],
+                                        comp.function_vs_zeta(z_test - zeta_cpu,
+                                                            beta0=beta0_cpu[0],
                                                             dzeta=1e-12)) * scale)
 
         xo.assert_allclose(getattr(particles, dict_p_bef[kk][0]) - dict_p_bef[kk][1],
@@ -180,12 +185,13 @@ def test_wake_kick_multi_bunch(test_context, kind):
         filling_scheme=filling_scheme,
         bunch_spacing_zeta=circumference/h_bunch,
         bunch_selection=bunch_selection,
-        circumference=circumference
+        circumference=circumference,
+        _context=test_context
         )
 
     line = xt.Line(elements=[wf])
-    line.build_tracker()
-    line.particle_ref=xp.Particles(p0c=p0c)
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(p0c=p0c)
 
     particles = xp.Particles(p0c=p0c,
                             zeta=wf.slicer.zeta_centers.flatten(),
@@ -219,6 +225,11 @@ def test_wake_kick_multi_bunch(test_context, kind):
 
     assert len(wf.components) == len(kind)
 
+    if hasattr(particles.zeta, 'get'):
+        particles_zeta = particles.zeta.get()
+    else:
+        particles_zeta = particles.zeta
+
     for comp, kk in zip(wf.components, kind):
         if comp.plane == 'z':
             scale = -particles.q0**2 * qe**2 / (
@@ -230,15 +241,20 @@ def test_wake_kick_multi_bunch(test_context, kind):
         assert comp.source_exponents == kind_to_parameters[kk]['source_exponents']
         assert comp.test_exponents == kind_to_parameters[kk]['test_exponents']
 
-        expected = np.zeros_like(particles.zeta)
+        expected = np.zeros_like(particles_zeta)
 
-        for i_test, z_test in enumerate(particles.zeta):
-            expected[i_test] += (particles.x[i_test]**comp.test_exponents[0] *
-                                particles.y[i_test]**comp.test_exponents[1] *
-                                np.dot(particles.x**comp.source_exponents[0] *
-                                        particles.y**comp.source_exponents[1],
-                                        comp.function_vs_zeta(z_test - particles.zeta,
-                                                            beta0=particles.beta0[0],
+        x_cpu = test_context.nparray_from_context_array(particles.x)
+        y_cpu = test_context.nparray_from_context_array(particles.y)
+        zeta_cpu = test_context.nparray_from_context_array(particles.zeta)
+        beta0_cpu = test_context.nparray_from_context_array(particles.beta0)
+
+        for i_test, z_test in enumerate(zeta_cpu):
+            expected[i_test] += (x_cpu[i_test]**comp.test_exponents[0] *
+                                 y_cpu[i_test]**comp.test_exponents[1] *
+                                 np.dot(x_cpu**comp.source_exponents[0] *
+                                        y_cpu**comp.source_exponents[1],
+                                        comp.function_vs_zeta(z_test - zeta_cpu,
+                                                            beta0=beta0_cpu[0],
                                                             dzeta=1e-12)) * scale)
 
         xo.assert_allclose(getattr(particles, dict_p_bef[kk][0]) - dict_p_bef[kk][1],
@@ -274,11 +290,13 @@ def test_beam_loading_theorem(test_context):
     delta_bef = particles.delta.copy()
 
     wf = xw.WakeResonator(kind='longitudinal', r=1e8, q=1e7, f_r=1e3)
-    wf.configure_for_tracking(zeta_range=zeta_range, num_slices=n_slices)
+    wf.configure_for_tracking(zeta_range=zeta_range, num_slices=n_slices,
+                              _context=test_context)
 
     line = xt.Line(elements=[wf],
                    element_names=['wf'])
-    line.build_tracker()
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(p0c=p0c, _context=test_context)
     line.track(particles, num_turns=1)
 
     scale = -particles.q0**2 * qe**2 / (qe * particles.p0c[0] * particles.beta0[0]
@@ -323,7 +341,9 @@ def test_wake_kick_multiturn(test_context, kind):
     wf = xw.WakeResonator(kind=kind,
                           r=1e8, q=1e7, f_r=1e3)
     wf.configure_for_tracking(zeta_range=zeta_range, num_slices=n_slices,
-                              num_turns=num_turns_wake, circumference=circumference)
+                              num_turns=num_turns_wake,
+                              circumference=circumference,
+                              _context=test_context)
 
 
     i_source = -10
@@ -356,46 +376,53 @@ def test_wake_kick_multiturn(test_context, kind):
 
     line = xt.Line(elements=[wf],
                    element_names=['wf'])
-    line.build_tracker()
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(p0c=p0c, _context=test_context)
     line.track(particles, num_turns=3)
 
     scale = particles.q0**2 * qe**2 / (
-        particles.p0c[0] * particles.beta0[0]* qe) * particles.weight[0]
+        p0c * particles.beta0[0]* qe) * particles.weight[0]
+
+    x_cpu = test_context.nparray_from_context_array(particles.x)
+    y_cpu = test_context.nparray_from_context_array(particles.y)
+    zeta_cpu = test_context.nparray_from_context_array(particles.zeta)
+    beta0_cpu = test_context.nparray_from_context_array(particles.beta0)
+    weight_cpu = test_context.nparray_from_context_array(particles.weight)
 
     wake_kwargs = {
-        'beta0': particles.beta0[0],
+        'beta0': beta0_cpu[0],
         'dzeta': 1e-20,
     }
 
     for comp, kk in zip(wf.components, kind):
         if comp.plane == 'z':
             scale = -particles.q0**2 * qe**2 / (
-                particles.p0c[0] * particles.beta0[0]* qe) * particles.weight[0]
+                p0c * beta0_cpu[0]* qe) * weight_cpu[0]
         else:
             scale = particles.q0**2 * qe**2 / (
-                particles.p0c[0] * particles.beta0[0]* qe) * particles.weight[0]
+                p0c * beta0_cpu[0]* qe) * weight_cpu[0]
         assert comp.plane == kind_to_parameters[kk]['plane']
         assert comp.source_exponents == kind_to_parameters[kk]['source_exponents']
         assert comp.test_exponents == kind_to_parameters[kk]['test_exponents']
 
-        expected = np.zeros_like(particles.zeta)
+        expected = np.zeros_like(zeta_cpu)
 
-        for i_test, z_test in enumerate(particles.zeta):
+        for i_test, z_test in enumerate(zeta_cpu):
             expected[i_test] += (
-                particles.x[i_test]**comp.test_exponents[0] *
-                particles.y[i_test]**comp.test_exponents[1] *
-                np.dot(particles.x**comp.source_exponents[0] *
-                particles.y**comp.source_exponents[1],
-                comp.function_vs_zeta(z_test - particles.zeta,
+                x_cpu[i_test]**comp.test_exponents[0] *
+                y_cpu[i_test]**comp.test_exponents[1] *
+                np.dot(x_cpu**comp.source_exponents[0] *
+                y_cpu**comp.source_exponents[1],
+                comp.function_vs_zeta(z_test - zeta_cpu,
                                       **wake_kwargs)) *
                 scale * (num_turns_wake + 1))
 
             expected[i_test] += (
-                particles.x[i_test]**comp.test_exponents[0] *
-                particles.y[i_test]**comp.test_exponents[1] *
-                np.dot(particles.x**comp.source_exponents[0] *
-                       particles.y**comp.source_exponents[1],
-                       comp.function_vs_zeta(z_test - particles.zeta -
+                x_cpu[i_test]**comp.test_exponents[0] *
+                y_cpu[i_test]**comp.test_exponents[1] *
+                np.dot(x_cpu**comp.source_exponents[0] *
+                       y_cpu**comp.source_exponents[1],
+                       comp.function_vs_zeta(z_test - zeta_cpu -
                                              circumference, **wake_kwargs)) *
                 scale * num_turns_wake)
 
@@ -428,7 +455,9 @@ def test_wake_kick_multiturn_reset(test_context, kind):
     wf = xw.WakeResonator(kind=kind,
                           r=1e8, q=1e7, f_r=1e3)
     wf.configure_for_tracking(zeta_range=zeta_range, num_slices=n_slices,
-                              num_turns=num_turns_wake, circumference=circumference)
+                              num_turns=num_turns_wake,
+                              circumference=circumference,
+                              _context=test_context)
 
 
     i_source = -10
@@ -449,7 +478,8 @@ def test_wake_kick_multiturn_reset(test_context, kind):
 
     line = xt.Line(elements=[wf],
                    element_names=['wf'])
-    line.build_tracker()
+    line.build_tracker(_context=test_context)
+    line.particle_ref = xp.Particles(p0c=p0c, _context=test_context)
     line.track(particles, num_turns=num_turns_wake)
 
     particles.weight *= 0
@@ -573,7 +603,8 @@ def test_wake_kick_multibunch_pipeline(test_context, kind):
                                 filling_scheme=filling_scheme,
                                 bunch_selection=bunch_selection_0,
                                 num_turns=n_turns_wake,
-                                circumference=circumference
+                                circumference=circumference,
+                                _context=test_context
                                 )
     wf_0._wake_tracker.init_pipeline(pipeline_manager=pipeline_manager,
                                         element_name='wake',
@@ -586,11 +617,12 @@ def test_wake_kick_multibunch_pipeline(test_context, kind):
                                 filling_scheme=filling_scheme,
                                 bunch_selection=bunch_selection_1,
                                 num_turns=n_turns_wake,
-                                circumference=circumference
+                                circumference=circumference,
+                                _context=test_context
                                 )
     wf_1._wake_tracker.init_pipeline(pipeline_manager=pipeline_manager,
-                                        element_name='wake',
-                                        partner_names=['b0'])
+                                     element_name='wake',
+                                     partner_names=['b0'])
 
     dict_p_bef_0 = {}
     dict_p_bef_1 = {}
@@ -612,8 +644,10 @@ def test_wake_kick_multibunch_pipeline(test_context, kind):
     line_0 = xt.Line(elements=[wf_0])
     line_1 = xt.Line(elements=[wf_1])
     print('Initialising multitracker')
-    line_0.build_tracker()
-    line_1.build_tracker()
+    line_0.build_tracker(_context=test_context)
+    line_1.build_tracker(_context=test_context)
+    line_0.particle_ref = xp.Particles(p0c=p0c, _context=test_context)
+    line_1.particle_ref = xp.Particles(p0c=p0c, _context=test_context)
     multitracker = xt.PipelineMultiTracker(
         branches=[xt.PipelineBranch(line=line_0, particles=particles_0),
                   xt.PipelineBranch(line=line_1, particles=particles_1)])
@@ -623,6 +657,14 @@ def test_wake_kick_multibunch_pipeline(test_context, kind):
     print('loading test data')
     particles_tot = xt.Particles.merge([particles_0, particles_1])
 
+    x_cpu = test_context.nparray_from_context_array(particles.x)
+    y_cpu = test_context.nparray_from_context_array(particles.y)
+    zeta_cpu = test_context.nparray_from_context_array(particles.zeta)
+    x_tot_cpu = test_context.nparray_from_context_array(particles_tot.x)
+    y_tot_cpu = test_context.nparray_from_context_array(particles_tot.y)
+    zeta_tot_cpu = test_context.nparray_from_context_array(particles.zeta)
+    beta0_cpu = test_context.nparray_from_context_array(particles.beta0)
+
     for particles, dict_p_bef, wf in [(particles_0, dict_p_bef_0, wf_0),
                                       (particles_1, dict_p_bef_1, wf_1)]:
 
@@ -631,24 +673,24 @@ def test_wake_kick_multibunch_pipeline(test_context, kind):
         for comp, kk in zip(wf.components, kind):
             if comp.plane == 'z':
                 scale = -particles.q0**2 * qe**2 / (
-                    particles.p0c[0] * particles.beta0[0]* qe) * particles.weight[0]
+                    p0c * beta0_cpu * qe) * particles.weight[0]
             else:
                 scale = particles.q0**2 * qe**2 / (
-                    particles.p0c[0] * particles.beta0[0]* qe) * particles.weight[0]
+                    p0c * beta0_cpu * qe) * particles.weight[0]
             assert comp.plane == kind_to_parameters[kk]['plane']
             assert comp.source_exponents == kind_to_parameters[kk]['source_exponents']
             assert comp.test_exponents == kind_to_parameters[kk]['test_exponents']
 
-            expected = np.zeros_like(particles.zeta)
+            expected = np.zeros_like(zeta_cpu)
 
-            for i_test, z_test in enumerate(particles.zeta):
-                expected[i_test] += (particles.x[i_test]**comp.test_exponents[0] *
-                                        particles.y[i_test]**comp.test_exponents[1] *
-                                        np.dot(particles_tot.x**comp.source_exponents[0] *
-                                            particles_tot.y**comp.source_exponents[1],
-                                            comp.function_vs_zeta(z_test - particles_tot.zeta,
-                                                                    beta0=particles_tot.beta0[0],
-                                                                    dzeta=1e-12)) * scale)
+            for i_test, z_test in enumerate(zeta_cpu):
+                expected[i_test] += (x_cpu[i_test]**comp.test_exponents[0] *
+                                     y_cpu[i_test]**comp.test_exponents[1] *
+                                     np.dot(x_tot_cpu**comp.source_exponents[0] *
+                                            y_tot_cpu**comp.source_exponents[1],
+                                            comp.function_vs_zeta(z_test - zeta_tot_cpu,
+                                                                  beta0=beta0_cpu[0],
+                                                                  dzeta=1e-12)) * scale)
 
             xo.assert_allclose(getattr(particles, dict_p_bef[kk][0]) - dict_p_bef[kk][1],
                     expected, rtol=1e-4, atol=1e-20)

--- a/xwakes/basewake.py
+++ b/xwakes/basewake.py
@@ -12,6 +12,7 @@ class BaseWake:
                                filling_scheme=None,
                                circumference=None,
                                bunch_selection=None,
+                               _context=None,
                                **kwargs # for multibunch compatibility
                                ) -> None:
         from xfields.beam_elements.waketracker import WakeTracker
@@ -24,9 +25,10 @@ class BaseWake:
             filling_scheme=filling_scheme,
             circumference=circumference,
             bunch_selection=bunch_selection,
+            _context=_context,
             **kwargs)
 
-    def _reconfigure_for_parallel(self, n_procs, my_rank) -> None:
+    def _reconfigure_for_parallel(self, n_procs, my_rank, _context) -> None:
 
         filled_slots = self._wake_tracker.slicer.filled_slots
         scheme = np.zeros(np.max(filled_slots) + 1,
@@ -44,6 +46,7 @@ class BaseWake:
                           bunch_selection=bunch_selection_rank[my_rank],
                           num_turns=self._wake_tracker.num_turns,
                           circumference=self._wake_tracker.circumference,
+                          _context=_context
                           )
 
     def track(self, particles) -> None:


### PR DESCRIPTION
## Description
With this PR we enable tracking with wakes on GPUs.
This PR must be merged after the corresponding one in xfields: [https://github.com/xsuite/xfields/pull/153](https://github.com/xsuite/xfields/pull/153)

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
