### PR TITLE
Minor bug fixes for new release of scipy and xtrack

### DIFF
--- a/tests/test_config_pipeline_for_wakes.py
+++ b/tests/test_config_pipeline_for_wakes.py
@@ -70,7 +70,7 @@ def test_config_pipeline_for_wakes(test_context):
 
         line = xt.Line(elements=[wake1, wake2, wake3, wake_no_config, drift])
 
-        particles = xt.Particles(context=test_context)
+        particles = xt.Particles(_context=test_context)
 
         pipeline_manager = xw.config_pipeline_for_wakes(particles, line, communicator,
                                     elements_to_configure=None)

--- a/xwakes/wit/devices.py
+++ b/xwakes/wit/devices.py
@@ -180,8 +180,8 @@ def _integral_stupakov(half_gap_small: float, half_gap_big: float,
 
     else:
         # computes numerically the integral instead of using its approximation
-        i, err = integrate.quadrature(_integrand_stupakov, half_gap_small, half_gap_big,
-                                      tol=1.e-3, maxiter=200, vec_func=False)
+        i, err = integrate.quad(_integrand_stupakov, half_gap_small,  # noqa
+                                half_gap_big, epsabs=1.e-3, limit=200)
 
     return i
 


### PR DESCRIPTION
## Description

Small fixes:

- `scipy.integrate.quadrature` was removed in 0.15.0
- `xt.Particles` requires `_context`, not `context` (an a recent release fixed a bug that allowed any parameters to be passed).