### PR TITLE
Fixes in MPI test

### DIFF
--- a/tests_mpi/test_wakefield_mpi.py
+++ b/tests_mpi/test_wakefield_mpi.py
@@ -150,7 +150,7 @@ def test_wakes_with_filling_scheme_mpi():
 
     for conv_data_mpi_key in conv_data_mpi_dict:
         assert conv_data_mpi_key in conv_data_ref_dict
-        if conv_data_mpi_key == 'component' or conv_data_mpi_key == 'waketracker':
+        if conv_data_mpi_key in ('component', 'waketracker', '_context'):
             continue
         xo.assert_allclose(conv_data_mpi_dict[conv_data_mpi_key],
                         conv_data_ref_dict[conv_data_mpi_key],


### PR DESCRIPTION
## Description

Needs xsuite/xfields#161. Xfields version 0.22.0 caused the MPI tests of Xwakes to start failing. The two PRs patch up the problem. In the future, a better assertion or a mechanism of comparison of `_ConvData` should be invented. 

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
