### PR TITLE
Fix sign of longitudinal wake when reading from headtail file

### DIFF
--- a/tests/test_xwakes_headtail_table_read.py
+++ b/tests/test_xwakes_headtail_table_read.py
@@ -34,7 +34,7 @@ def test_headail_table_read():
     for i_component, component in enumerate(wake_file_columns):
         if component != 'time':
             if component == 'longitudinal':
-                conversion_factor = 1E12
+                conversion_factor = -1E12
             else:
                 conversion_factor = 1E15
 

--- a/xwakes/read_headtail_table.py
+++ b/xwakes/read_headtail_table.py
@@ -36,7 +36,7 @@ def read_headtail_file(wake_file, wake_file_columns):
         if component != 'time':
             assert component in valid_wake_components
             if component == 'longitudinal':
-                conversion_factor = 1E12
+                conversion_factor = -1E12
             else:
                 conversion_factor = 1E15
 


### PR DESCRIPTION
## Description

The sign convention of the longitudinal wake (positive means energy loss) is opposite to PyHT. The sign changed is adjusted in the conversion factor when reading the file.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
