### PR TITLE
Bugfix: Collective Monitor was not declared as collective

### DIFF
--- a/examples/000a_sps_tune_shift.py
+++ b/examples/000a_sps_tune_shift.py
@@ -10,7 +10,6 @@ import h5py
 
 import xwakes as xw
 import xtrack as xt
-import xfields as xf
 import xpart as xp
 import nafflib
 

--- a/examples/000a_sps_tune_shift.py
+++ b/examples/000a_sps_tune_shift.py
@@ -64,7 +64,7 @@ wf_sps.configure_for_tracking(
 )
 
 # initialize a damper with 100 turns gain
-transverse_damper = xf.TransverseDamper(
+transverse_damper = xw.TransverseDamper(
     gain_x=2/100, gain_y=2/100,
     zeta_range=(-0.5*bucket_length, 0.5*bucket_length),
     num_slices=100,
@@ -73,7 +73,7 @@ transverse_damper = xf.TransverseDamper(
 )
 
 # initialize a monitor for the average transverse positions
-monitor = xf.CollectiveMonitor(
+monitor = xw.CollectiveMonitor(
     base_file_name=f'sps_tune_shift',
     monitor_bunches=True,
     monitor_slices=False,

--- a/examples/000b_sps_tune_shift_multibunch.py
+++ b/examples/000b_sps_tune_shift_multibunch.py
@@ -3,14 +3,12 @@
 # Copyright (c) CERN, 2024.                 #
 # ######################################### #
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pathlib
 import h5py
 
 import xwakes as xw
 import xtrack as xt
-import xfields as xf
 import xpart as xp
 import nafflib
 
@@ -71,7 +69,7 @@ wf_sps.configure_for_tracking(
 )
 
 # initialize a damper with 100 turns gain
-transverse_damper = xf.TransverseDamper(
+transverse_damper = xw.TransverseDamper(
     gain_x=2/100, gain_y=2/100,
     zeta_range=(-0.5*bucket_length, 0.5*bucket_length),
     num_slices=100,
@@ -81,7 +79,7 @@ transverse_damper = xf.TransverseDamper(
 )
 
 # initialize a monitor for the average transverse positions
-monitor = xf.CollectiveMonitor(
+monitor = xw.CollectiveMonitor(
     base_file_name=f'sps_tune_shift',
     monitor_bunches=True,
     monitor_slices=False,

--- a/examples/000c_sps_tune_shift_multibunch_mpi.py
+++ b/examples/000c_sps_tune_shift_multibunch_mpi.py
@@ -11,7 +11,6 @@ from mpi4py import MPI
 
 import xwakes as xw
 import xtrack as xt
-import xfields as xf
 import xpart as xp
 import nafflib
 
@@ -77,7 +76,7 @@ wf_sps.configure_for_tracking(
 )
 
 # initialize a damper with 100 turns gain
-transverse_damper = xf.TransverseDamper(
+transverse_damper = xw.TransverseDamper(
     gain_x=2/100, gain_y=2/100,
     zeta_range=(-0.5*bucket_length, 0.5*bucket_length),
     num_slices=100,
@@ -88,7 +87,7 @@ transverse_damper = xf.TransverseDamper(
 
 # initialize a monitor for the average transverse positions
 my_rank = MPI.COMM_WORLD.Get_rank()
-monitor = xf.CollectiveMonitor(
+monitor = xw.CollectiveMonitor(
     base_file_name=f'sps_tune_shift_rank{my_rank}',
     monitor_bunches=True,
     monitor_slices=False,

--- a/xwakes/beam_elements/collective_monitor.py
+++ b/xwakes/beam_elements/collective_monitor.py
@@ -73,6 +73,8 @@ class CollectiveMonitor(ElementWithSlicer):
         Use flattened wakes
     """
 
+    iscollective = True
+
     _stats_to_store = [
         'mean_x', 'mean_px', 'mean_y', 'mean_py', 'mean_zeta',
         'mean_delta', 'sigma_x', 'sigma_y', 'sigma_zeta',


### PR DESCRIPTION
## Description

Fix a bug that caused `symbol not found in flat namespace '_CollectiveMonitor_track_local_particle'`: the CollectiveMonitor needs to be declare as a collective element.

Closes xsuite/xsuite#621.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
