### PR TITLE
Fix left over bug (Wakefield -> WakeTracker in xfields)

### DIFF
--- a/xwakes/wit/component.py
+++ b/xwakes/wit/component.py
@@ -233,7 +233,7 @@ class Component:
                                **kwargs # for multibuunch compatibility
                                ) -> None:
         import xfields as xf
-        self._xfields_wf = xf.Wakefield(components=[self], zeta_range=zeta_range,
+        self._xfields_wf = xf.WakeTracker(components=[self], zeta_range=zeta_range,
                                         num_slices=num_slices, **kwargs)
 
     def track(self, particles):
@@ -794,6 +794,7 @@ class ComponentClassicThickWall(Component):
 
         if isscalar:
             out = out[0]
+            
         return out
 
     @staticmethod


### PR DESCRIPTION
## Description

A small fix of a bug that was I guess left over when WakeField was changed to WakeTracker in xfields. It did not appear in the tests since it is only called when a component is configured for tracking individually.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
